### PR TITLE
Bug: Unknown Guild al comprobar los canales en directo de Twitch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "mongodb": "^6.7.0",
         "mongoose": "^8.4.3",
         "ms": "^2.1.3",
+        "node-cron": "^4.2.1",
         "octokit": "^5.0.5",
         "play-dl": "^1.9.7",
         "pretty-ms": "^9.0.0",
@@ -1046,6 +1047,8 @@
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "node-cron": ["node-cron@4.2.1", "", {}, "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mongodb": "^6.7.0",
     "mongoose": "^8.4.3",
     "ms": "^2.1.3",
+    "node-cron": "^4.2.1",
     "octokit": "^5.0.5",
     "play-dl": "^1.9.7",
     "pretty-ms": "^9.0.0"

--- a/src/events/ready/checkTwitch.ts
+++ b/src/events/ready/checkTwitch.ts
@@ -1,58 +1,62 @@
+import cron from 'node-cron';
 import { Client, TextChannel } from 'discord.js';
 import { TwitchNotificationConfig } from '../../models/TwitchNotificationConfig';
 import { getTwitchChannelStream } from '../../lib/twitch';
 
+// Production: every 60 seconds -> '* * * * *'
+// Development: every 10 seconds -> '*/10 * * * * *'
+const cronExpression = process.env.NODE_ENV === 'production' ? '* * * * *' : '*/10 * * * * *';
+
 export default function (client: Client) {
-   const checkTwitch = async () => {
-      try {
-         const notificationConfigs = await TwitchNotificationConfig.find();
-         for (const notificationConfig of notificationConfigs) {
-            const stream = await getTwitchChannelStream(notificationConfig.twitchChannelName);
+   cron.schedule(cronExpression, () => checkTwitchStreams(client), { timezone: 'Europe/Madrid' });
+}
 
-            const wasLive = notificationConfig.isLive;
-            const isCurrentlyLive = stream !== null;
+async function checkTwitchStreams(client: Client) {
+   try {
+      const notificationConfigs = await TwitchNotificationConfig.find();
+      for (const notificationConfig of notificationConfigs) {
+         const stream = await getTwitchChannelStream(notificationConfig.twitchChannelName);
 
-            if (isCurrentlyLive && !wasLive) {
-               const cachedGuild = client.guilds.cache.get(notificationConfig.guildId);
-               if (!cachedGuild) continue;
+         const wasLive = notificationConfig.isLive;
+         const isCurrentlyLive = stream !== null;
 
-               const targetChannel = cachedGuild.channels.cache.get(notificationConfig.notificationChannelId) as TextChannel;
-               if (!targetChannel) {
-                  console.error(`No se ha encontrado el canal de notificaciones con ID ${notificationConfig.notificationChannelId}`);
-                  continue;
-               }
+         if (isCurrentlyLive && !wasLive) {
+            const cachedGuild = client.guilds.cache.get(notificationConfig.guildId);
+            if (!cachedGuild) continue;
 
-               const streamTitle = stream.title;
-               const streamGame = stream.gameName;
-               const streamUrl = `https://www.twitch.tv/${notificationConfig.twitchChannelName}`;
-               const streamerName = stream.userDisplayName;
-               const thumbnailUrl = stream.getThumbnailUrl(1280, 720);
-
-               notificationConfig.isLive = true;
-               notificationConfig.lastStreamId = stream.id;
-
-               await notificationConfig.save();
-
-               const targetMessage =
-                  notificationConfig.customMessage
-                     ?.replace('{streamUrl}', streamUrl)
-                     ?.replace('{streamTitle}', streamTitle)
-                     ?.replace('{streamerName}', streamerName)
-                     ?.replace('{gameName}', streamGame || 'Sin categoría')
-                     ?.replace('{thumbnailUrl}', thumbnailUrl) ||
-                  `🔴 **${streamerName}** está en directo!\n**${streamTitle}**\nJugando a: ${streamGame || 'Sin categoría'}\n${streamUrl}`;
-
-               await targetChannel.send(targetMessage);
-            } else if (!isCurrentlyLive && wasLive) {
-               notificationConfig.isLive = false;
-               await notificationConfig.save();
+            const targetChannel = cachedGuild.channels.cache.get(notificationConfig.notificationChannelId) as TextChannel;
+            if (!targetChannel) {
+               console.error(`No se ha encontrado el canal de notificaciones con ID ${notificationConfig.notificationChannelId}`);
+               continue;
             }
-         }
-      } catch (error) {
-         console.error(`Hubo un error al comprobar los streams de Twitch: ${error}`);
-      }
-   };
 
-   checkTwitch();
-   setInterval(checkTwitch, 60000);
+            const streamTitle = stream.title;
+            const streamGame = stream.gameName;
+            const streamUrl = `https://www.twitch.tv/${notificationConfig.twitchChannelName}`;
+            const streamerName = stream.userDisplayName;
+            const thumbnailUrl = stream.getThumbnailUrl(1280, 720);
+
+            notificationConfig.isLive = true;
+            notificationConfig.lastStreamId = stream.id;
+
+            await notificationConfig.save();
+
+            const targetMessage =
+               notificationConfig.customMessage
+                  ?.replace('{streamUrl}', streamUrl)
+                  ?.replace('{streamTitle}', streamTitle)
+                  ?.replace('{streamerName}', streamerName)
+                  ?.replace('{gameName}', streamGame || 'Sin categoría')
+                  ?.replace('{thumbnailUrl}', thumbnailUrl) ||
+               `🔴 **${streamerName}** está en directo!\n**${streamTitle}**\nJugando a: ${streamGame || 'Sin categoría'}\n${streamUrl}`;
+
+            await targetChannel.send(targetMessage);
+         } else if (!isCurrentlyLive && wasLive) {
+            notificationConfig.isLive = false;
+            await notificationConfig.save();
+         }
+      }
+   } catch (error) {
+      console.error(`Hubo un error al comprobar los streams de Twitch: ${error}`);
+   }
 }


### PR DESCRIPTION
Se ha resuelto el error que provocaba que el bot buscase en Guilds en las que no se encontraba, por lo tanto, enviaba un mensaje de error a la consola como consecuencia de que no encontraba la Guild, ya que daba conflicto con el bot de producción.

Adicionalmente se ha realizado la implementación de la librería node-cron para manejar de forma mas eficiente y cómoda los crons. Y se ha eliminado la implementación anterior.

### Cómo probar los cambios

1. Encender el bot
2. Revisar que en la consola no aparezca el mensaje de error de Unknown Guild para el evento checkTwitch.
3. Una vez revisado, probar el propio comando con la nueva implementación para asegurar su correcto funcionamiento.