### PR TITLE
Bug: No se puede interactuar con los botones de los informes y sugerencias

### DIFF
--- a/src/commands/general/report.ts
+++ b/src/commands/general/report.ts
@@ -3,6 +3,8 @@ import {
    ButtonBuilder,
    ButtonStyle,
    EmbedBuilder,
+   InteractionContextType,
+   MessageFlags,
    ModalBuilder,
    ModalSubmitInteraction,
    SlashCommandBuilder,
@@ -16,7 +18,7 @@ import { Report } from '../../models/Report';
 
 export const run = async ({ interaction }: CommandProps) => {
    if (!interaction.guild) {
-      interaction.reply({
+      await interaction.reply({
          content: 'Solo puedes ejecutar este comando en un servidor.',
          ephemeral: true,
       });
@@ -74,7 +76,7 @@ export const run = async ({ interaction }: CommandProps) => {
          })
          .catch(error => console.error(`Hubo un error en los informes: ${error}`))) as ModalSubmitInteraction;
 
-      await modalInteraction.deferReply({ ephemeral: true });
+      await modalInteraction.deferReply({ flags: MessageFlags.Ephemeral });
 
       let reportMessage;
 
@@ -129,7 +131,7 @@ export const run = async ({ interaction }: CommandProps) => {
       const row = new ActionRowBuilder<ButtonBuilder>().addComponents(solveButton, fakeButton);
 
       reportMessage.edit({
-         content: `${interaction.user} Informe creado.`,
+         content: null,
          embeds: [reportEmbed],
          components: [row],
       });
@@ -138,4 +140,7 @@ export const run = async ({ interaction }: CommandProps) => {
    }
 };
 
-export const data = new SlashCommandBuilder().setName('report').setDescription('Crea un informe sobre un bug.').setDMPermission(false);
+export const data = new SlashCommandBuilder()
+   .setName('report')
+   .setDescription('Crea un informe sobre un bug.')
+   .setContexts([InteractionContextType.Guild]);

--- a/src/events/interactionCreate/handleReports.ts
+++ b/src/events/interactionCreate/handleReports.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Interaction } from 'discord.js';
+import { EmbedBuilder, Interaction, MessageFlags } from 'discord.js';
 import { Report } from '../../models/Report';
 
 export default async function (interaction: Interaction) {
@@ -11,30 +11,30 @@ export default async function (interaction: Interaction) {
 
       if (type !== 'report') return;
 
-      await interaction.deferReply({ ephemeral: true });
+      if (!interaction.memberPermissions?.has('Administrator')) {
+         await interaction.editReply('No tienes permisos para marcar como solucionado un informe.');
+         return;
+      }
+
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       const targetReport = await Report.findOne({ reportId });
-      const targetReportId = targetReport?.reportId;
 
-      if (!targetReportId) {
+      if (!targetReport) {
          await interaction.editReply('No se ha encontrado el informe.');
          return;
       }
 
-      const targetMessage = await interaction.channel?.messages.fetch(targetReportId);
+      const targetMessageId = targetReport.messageId;
+      const targetMessage = await interaction.channel?.messages.fetch(targetMessageId);
       const targetMessageEmbed = targetMessage?.embeds[0];
 
+      if (!targetMessageEmbed) {
+         await interaction.editReply('Ha ocurrido un error al obtener el mensaje del informe.');
+         return;
+      }
+
       if (action === 'solved') {
-         if (!interaction.memberPermissions?.has('Administrator')) {
-            await interaction.editReply('No tienes permisos para marcar como solucionado un informe.');
-            return;
-         }
-
-         if (!targetMessageEmbed) {
-            await interaction.editReply('Ha ocurrido un error al obtener el mensaje del informe.');
-            return;
-         }
-
          targetMessageEmbed.fields[2].value = '✅ Solucionado';
          const updatedEmbed = EmbedBuilder.from(targetMessageEmbed).setColor(0x84e660);
 
@@ -42,24 +42,11 @@ export default async function (interaction: Interaction) {
 
          interaction.editReply('Error solucionado. Muchas gracias por su informe.');
 
-         targetMessage?.edit({
-            embeds: [updatedEmbed],
-            components: [],
-         });
+         targetMessage?.edit({ embeds: [updatedEmbed], components: [] });
          return;
       }
 
       if (action === 'fake') {
-         if (!interaction.memberPermissions?.has('Administrator')) {
-            await interaction.editReply('No tienes permisos para marcar como falso un informe.');
-            return;
-         }
-
-         if (!targetMessageEmbed) {
-            await interaction.editReply('Ha ocurrido un error al obtener el mensaje del informe.');
-            return;
-         }
-
          targetMessageEmbed.fields[2].value = '❕ Falso';
          const updatedEmbed = EmbedBuilder.from(targetMessageEmbed).setColor(0xffffff);
 
@@ -67,10 +54,7 @@ export default async function (interaction: Interaction) {
 
          interaction.editReply('Informe falso. Se tomaran medidas con el usuario conveniente por divulgar información falsa.');
 
-         targetMessage?.edit({
-            embeds: [updatedEmbed],
-            components: [],
-         });
+         targetMessage?.edit({ embeds: [updatedEmbed], components: [] });
          return;
       }
    } catch (error) {


### PR DESCRIPTION
Se han resuelto los siguientes errores:

- No permitía interactuar con los botones de los informes ya que se utilizaba un ID incorrecto que no era el ID del mensaje que contenía el informe, ya se utiliza el ID del mensaje correctamente.
- Se actualizaban los campos incorrectamente en las cuatro posibles acciones de las sugerencias: aceptar, rechazar, a favor y en contra. Ya se actualizan los campos correctos del mensaje que contiene la sugerencia.
- Eliminar advertencias de deprecación tanto en consola como en el editor de la librería Discord.js, en concreto las que tienen que ver con los permisos por DM y con los mensajes enviados al usuario que realiza la interacción, ya que se ha cambiado cómo funcionan dichas características en la librería.
- Se han hecho cambios menores de mejora del código en ambos comandos y eventos.

### Cómo probar los cambios

1. Encender el bot
2. Utilizar el comando `/report` y/o `/suggest`.
3. Interactuar con cada botón e interacción posible tanto para los informes como para las sugerencias y asegurar que funcionan correctamente.