### PR TITLE
Comando /weekly para recompensa semanal

### DIFF
--- a/src/commands/economy/weekly.ts
+++ b/src/commands/economy/weekly.ts
@@ -1,0 +1,53 @@
+import { InteractionContextType, MessageFlags, SlashCommandBuilder } from 'discord.js';
+import { CommandProps } from '../../lib/types';
+import { User } from '../../models/User';
+
+const WEEKLY_AMOUNT = 5000;
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const run = async ({ interaction }: CommandProps) => {
+   try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const query = {
+         userId: interaction.member?.user.id,
+         guildId: interaction.guild?.id,
+      };
+
+      let user = await User.findOne(query);
+
+      if (user) {
+         const now = new Date();
+         const lastWeekly = user.lastWeekly;
+         const timeDiff = now.getTime() - lastWeekly.getTime();
+
+         if (timeDiff < WEEK_IN_MS) {
+            const remaining = WEEK_IN_MS - timeDiff;
+            const days = Math.floor(remaining / (24 * 60 * 60 * 1000));
+            const hours = Math.floor((remaining % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+            const minutes = Math.floor((remaining % (60 * 60 * 1000)) / (60 * 1000));
+
+            interaction.editReply(`Debes esperar ${days}d ${hours}h ${minutes}m para reclamar tu recompensa semanal.`);
+            return;
+         }
+      } else {
+         user = new User({
+            ...query,
+            lastWeekly: new Date(),
+         });
+      }
+
+      user.balance += WEEKLY_AMOUNT;
+      user.lastWeekly = new Date();
+      await user.save();
+
+      interaction.editReply(`${WEEKLY_AMOUNT} gramos de cocaína fueron agregadas a tu inventario. Ahora mismo tienes ${user.balance}`);
+   } catch (error) {
+      console.error(`Ha ocurrido un error con las semanales: ${error}`);
+   }
+};
+
+export const data = new SlashCommandBuilder()
+   .setName('weekly')
+   .setDescription('Recolecta tu recompensa semanal.')
+   .setContexts([InteractionContextType.Guild]);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -19,6 +19,10 @@ const userSchema = new Schema({
       type: Date,
       default: new Date(),
    },
+   lastWeekly: {
+      type: Date,
+      default: new Date(0),
+   },
    lastWordle: {
       type: Date,
       default: new Date(),


### PR DESCRIPTION
Se ha añadido el comando `/weekly` el cual te permite reclamar una recompensa semanal de 5.000 gramos.

### Cómo probar los cambios

1. Encender el bot
2. Usar el comando `/balance` para ver tu cantidad de gramos inicial.
3. Utilizar el comando `/weekly` en un canal y revisar con `/balance` para asegurar que se transfirió la cantidad correctamente.
4. Volver a utilizar el comando y revisar que tienes que esperar 7 días para poder volver a usarlo.