### PR TITLE
feat(economy): add /burn command and weekly burners ranking

### DIFF
--- a/src/commands/admin/burners-ranking.ts
+++ b/src/commands/admin/burners-ranking.ts
@@ -1,0 +1,63 @@
+import { InteractionContextType, MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { CommandProps } from '../../lib/types';
+import { BurnSettings } from '../../models/BurnSettings';
+
+export const run = async ({ interaction }: CommandProps) => {
+   if (!interaction.guild) {
+      await interaction.reply({
+         content: 'Solo puedes ejecutar este comando en un servidor.',
+         flags: MessageFlags.Ephemeral,
+      });
+      return;
+   }
+
+   const subcommand = interaction.options.getSubcommand();
+   const guildId = interaction.guild.id;
+
+   try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      switch (subcommand) {
+         case 'configure': {
+            const channel = interaction.options.getChannel('channel', true);
+            const role = interaction.options.getRole('role', true);
+
+            await BurnSettings.findOneAndUpdate({ guildId }, { channelId: channel.id, roleId: role.id }, { upsert: true, new: true });
+
+            await interaction.editReply(
+               `✅ Ranking de quemadores configurado. Se publicará en <#${channel.id}> y el rol <@&${role.id}> se asignará al top derrochador semanal.`
+            );
+            break;
+         }
+         case 'disable': {
+            const existing = await BurnSettings.findOne({ guildId });
+
+            if (!existing) {
+               await interaction.editReply('No hay ningún ranking de quemadores configurado en este servidor.');
+               return;
+            }
+
+            await existing.deleteOne();
+            await interaction.editReply('✅ Ranking de quemadores deshabilitado correctamente.');
+            break;
+         }
+      }
+   } catch (error) {
+      console.error(`Ha ocurrido un error con el comando 'burners-ranking': ${error}`);
+      await interaction.editReply('Hubo un error al procesar el comando.');
+   }
+};
+
+export const data = new SlashCommandBuilder()
+   .setName('burners-ranking')
+   .setDescription('Configurar el ranking semanal de quemadores de gramos.')
+   .setContexts([InteractionContextType.Guild])
+   .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+   .addSubcommand(subcommand =>
+      subcommand
+         .setName('configure')
+         .setDescription('Configurar el canal y rol del ranking semanal de quemadores.')
+         .addChannelOption(option => option.setName('channel').setDescription('Canal donde se publicará el ranking semanal.').setRequired(true))
+         .addRoleOption(option => option.setName('role').setDescription('Rol que se asignará al mayor quemador de la semana.').setRequired(true))
+   )
+   .addSubcommand(subcommand => subcommand.setName('disable').setDescription('Deshabilitar el ranking semanal de quemadores.'));

--- a/src/commands/economy/burn.ts
+++ b/src/commands/economy/burn.ts
@@ -1,0 +1,88 @@
+import { InteractionContextType, MessageFlags, SlashCommandBuilder } from 'discord.js';
+import mongoose from 'mongoose';
+import { CommandProps } from '../../lib/types';
+import { Burn } from '../../models/Burn';
+import { User } from '../../models/User';
+import { getIsoWeekId } from '../../utils/date';
+
+export const run = async ({ interaction }: CommandProps) => {
+   if (!interaction.guild) {
+      await interaction.reply({
+         content: 'Solo puedes ejecutar este comando en un servidor.',
+         flags: MessageFlags.Ephemeral,
+      });
+      return;
+   }
+
+   const amount = interaction.options.getInteger('amount', true);
+   const guildId = interaction.guild.id;
+   const userId = interaction.user.id;
+
+   if (amount < 1) {
+      await interaction.reply({
+         content: 'Tienes que quemar como mínimo 1 gramo de cocaína.',
+         flags: MessageFlags.Ephemeral,
+      });
+      return;
+   }
+
+   const user = await User.findOne({ userId, guildId });
+
+   if (!user) {
+      await interaction.reply({
+         content: 'No estás en el sistema monetario. Prueba a usar el comando /daily.',
+         flags: MessageFlags.Ephemeral,
+      });
+      return;
+   }
+
+   if (user.balance < amount) {
+      await interaction.reply({
+         content: `No tienes ${amount} gramos para quemar.`,
+         flags: MessageFlags.Ephemeral,
+      });
+      return;
+   }
+
+   try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const weekId = getIsoWeekId();
+
+      const session = await mongoose.startSession();
+      session.startTransaction();
+
+      await User.updateOne({ userId, guildId }, { $inc: { balance: -amount, totalBurned: amount } }, { session });
+      await Burn.create([{ guildId, userId, amount, weekId }], { session });
+
+      await session.commitTransaction();
+      session.endSession();
+
+      const updatedUser = await User.findOne({ userId, guildId });
+
+      const weeklyRanking = await Burn.aggregate([
+         { $match: { guildId, weekId } },
+         { $group: { _id: '$userId', total: { $sum: '$amount' }, firstBurn: { $min: '$createdAt' } } },
+         { $sort: { total: -1, firstBurn: 1 } },
+      ]);
+
+      const rank = weeklyRanking.findIndex(entry => entry._id === userId) + 1;
+
+      await interaction.editReply({
+         content: `🔥 Quemaste **${amount}** gramos. Tu saldo actual es **${updatedUser?.balance ?? 0}** gramos.`,
+      });
+
+      await interaction.followUp({
+         content: `🔥 <@${userId}> acaba de quemar **${amount}** gramos y ocupa el **#${rank}** en el ranking semanal de derrochadores.`,
+      });
+   } catch (error) {
+      console.error(`Ha ocurrido un error con el comando 'burn': ${error}`);
+      await interaction.editReply({ content: 'Hubo un error al procesar la quema de gramos.' });
+   }
+};
+
+export const data = new SlashCommandBuilder()
+   .setName('burn')
+   .setDescription('Quema gramos de cocaína voluntariamente.')
+   .setContexts([InteractionContextType.Guild])
+   .addIntegerOption(option => option.setName('amount').setDescription('La cantidad de gramos que quieres quemar.').setRequired(true).setMinValue(1));

--- a/src/events/ready/rankBurners.ts
+++ b/src/events/ready/rankBurners.ts
@@ -1,0 +1,91 @@
+import cron from 'node-cron';
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { Burn } from '../../models/Burn';
+import { BurnSettings } from '../../models/BurnSettings';
+import { getIsoWeekId } from '../../utils/date';
+
+// Production: every Sunday at 21:00 -> '0 21 * * 0'
+// Development: every minute -> '* * * * *'
+const cronExpression = process.env.NODE_ENV === 'production' ? '0 21 * * 0' : '* * * * *';
+
+export default function (client: Client) {
+   cron.schedule(cronExpression, () => publishBurnersRanking(client), { timezone: 'Europe/Madrid' });
+}
+
+async function publishBurnersRanking(client: Client) {
+   try {
+      const allSettings = await BurnSettings.find();
+
+      for (const settings of allSettings) {
+         const { guildId, channelId, roleId } = settings;
+
+         const guild = client.guilds.cache.get(guildId);
+         if (!guild) continue;
+
+         const channel = guild.channels.cache.get(channelId) as TextChannel;
+         if (!channel) {
+            console.error(`[rankBurners] Canal no encontrado: ${channelId} en guild ${guildId}`);
+            continue;
+         }
+
+         const weekId = getIsoWeekId();
+
+         const topBurners = await Burn.aggregate([
+            { $match: { guildId, weekId } },
+            { $group: { _id: '$userId', total: { $sum: '$amount' }, firstBurn: { $min: '$createdAt' } } },
+            { $sort: { total: -1, firstBurn: 1 } },
+            { $limit: 10 },
+         ]);
+
+         const embed = new EmbedBuilder()
+            .setTitle('🔥 Ranking Semanal de Derrochadores 🔥')
+            .setColor(0xe74c3c)
+            .setTimestamp()
+            .setFooter({ text: `Semana ${weekId}` });
+
+         if (topBurners.length === 0) {
+            embed.setDescription('Nadie quemó gramos esta semana. ¡Empezad a derrochar!');
+            await channel.send({ embeds: [embed] });
+            continue;
+         }
+
+         const medals = ['🥇', '🥈', '🥉'];
+         const description = topBurners
+            .map((entry, i) => {
+               const position = i < 3 ? medals[i] : `**${i + 1}.**`;
+               return `${position} <@${entry._id}>: **${entry.total}** gramos quemados`;
+            })
+            .join('\n');
+
+         embed.setDescription(description);
+         await channel.send({ embeds: [embed] });
+
+         const topUserId = topBurners[0]._id as string;
+
+         const role = await guild.roles.fetch(roleId).catch(() => null);
+         if (!role) {
+            console.error(`[rankBurners] Rol no encontrado: ${roleId} en guild ${guildId}`);
+            continue;
+         }
+
+         for (const [, member] of role.members) {
+            if (member.id === topUserId) continue;
+            await member.roles.remove(role).catch(err => console.error(`[rankBurners] Error al retirar rol de ${member.id}: ${err}`));
+         }
+
+         const topMember = await guild.members.fetch(topUserId).catch(() => null);
+         if (!topMember) {
+            console.error(`[rankBurners] Miembro no encontrado: ${topUserId} en guild ${guildId}`);
+            continue;
+         }
+
+         if (!topMember.roles.cache.has(roleId)) {
+            await topMember.roles.add(role).catch(err => console.error(`[rankBurners] Error al asignar rol a ${topUserId}: ${err}`));
+         }
+
+         await BurnSettings.updateOne({ guildId }, { currentHolderId: topUserId });
+      }
+   } catch (error) {
+      console.error(`[rankBurners] Error en el cron de ranking de quemadores: ${error}`);
+   }
+}

--- a/src/models/Burn.ts
+++ b/src/models/Burn.ts
@@ -1,0 +1,29 @@
+import { Schema, model } from 'mongoose';
+
+const burnSchema = new Schema({
+   guildId: {
+      type: String,
+      required: true,
+   },
+   userId: {
+      type: String,
+      required: true,
+   },
+   amount: {
+      type: Number,
+      required: true,
+   },
+   weekId: {
+      type: String,
+      required: true,
+   },
+   createdAt: {
+      type: Date,
+      default: Date.now,
+   },
+});
+
+burnSchema.index({ guildId: 1, weekId: 1 });
+burnSchema.index({ guildId: 1, userId: 1, weekId: 1 });
+
+export const Burn = model('Burn', burnSchema);

--- a/src/models/BurnSettings.ts
+++ b/src/models/BurnSettings.ts
@@ -1,0 +1,23 @@
+import { Schema, model } from 'mongoose';
+
+const burnSettingsSchema = new Schema({
+   guildId: {
+      type: String,
+      required: true,
+      unique: true,
+   },
+   channelId: {
+      type: String,
+      required: true,
+   },
+   roleId: {
+      type: String,
+      required: true,
+   },
+   currentHolderId: {
+      type: String,
+      default: '',
+   },
+});
+
+export const BurnSettings = model('BurnSettings', burnSettingsSchema);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -77,6 +77,10 @@ const userSchema = new Schema({
       type: Number,
       default: 0,
    },
+   totalBurned: {
+      type: Number,
+      default: 0,
+   },
 });
 
 export const User = model('User', userSchema);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,3 +1,12 @@
+export function getIsoWeekId(date: Date = new Date()): string {
+   const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+   const dayOfWeek = d.getUTCDay() || 7;
+   d.setUTCDate(d.getUTCDate() + 4 - dayOfWeek);
+   const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+   const weekNumber = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+   return `${d.getUTCFullYear()}-W${weekNumber < 10 ? '0' : ''}${weekNumber}`;
+}
+
 export function isDateAfterDays(date: Date, days: number) {
    const currentDate = new Date();
    const difference = currentDate.getTime() - date.getTime();


### PR DESCRIPTION
## Summary

- Adds `/burn <amount>` command that deducts coins from the user's balance, records the burn in a new `Burn` collection (via Mongoose transaction), and posts a public follow-up showing the user's current weekly rank
- Adds `/burners-ranking configure <channel> <role>` and `disable` admin commands to set up where the weekly ranking is posted and which role goes to the top burner
- Adds a weekly cron (Sunday 21:00 Europe/Madrid, same slot as the meme ranking) that posts a top-10 embed and rotates the special "Derrochador de la semana" role

## New files

| File | Purpose |
|---|---|
| `src/models/Burn.ts` | Burn event document — `userId`, `guildId`, `amount`, `weekId` (ISO `YYYY-WNN`), `createdAt` |
| `src/models/BurnSettings.ts` | Per-guild config — `channelId`, `roleId`, `currentHolderId` |
| `src/commands/economy/burn.ts` | `/burn` slash command |
| `src/commands/admin/burners-ranking.ts` | `/burners-ranking` admin config command |
| `src/events/ready/rankBurners.ts` | Weekly cron handler |

## Changed files

| File | Change |
|---|---|
| `src/models/User.ts` | Added `totalBurned` field (mirrors `totalDonated`) |
| `src/utils/date.ts` | Added `getIsoWeekId()` utility |

Closes #106